### PR TITLE
05-paging

### DIFF
--- a/app/src/androidTest/java/com/karumi/jetpack/superheroes/ui/view/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/karumi/jetpack/superheroes/ui/view/MainActivityTest.kt
@@ -1,5 +1,8 @@
 package com.karumi.jetpack.superheroes.ui.view
 
+import android.os.Looper
+import androidx.paging.PagedList
+import androidx.paging.PositionalDataSource
 import com.karumi.jetpack.superheroes.data.repository.SuperHeroRepository
 import com.karumi.jetpack.superheroes.data.singleValueLiveData
 import com.karumi.jetpack.superheroes.domain.model.SuperHero
@@ -9,6 +12,7 @@ import org.kodein.di.Kodein
 import org.kodein.di.erased.bind
 import org.kodein.di.erased.instance
 import org.mockito.Mock
+import java.util.concurrent.Executors.newSingleThreadExecutor
 
 class MainActivityTest : AcceptanceTest<MainActivity>(MainActivity::class.java) {
 
@@ -64,6 +68,11 @@ class MainActivityTest : AcceptanceTest<MainActivity>(MainActivity::class.java) 
         compareScreenshot(activity)
     }
 
+    private fun compareScreenshot(activity: MainActivity) {
+        Thread.sleep(100)
+        super.compareScreenshot(activity)
+    }
+
     private fun givenThereAreSomeAvengers(numberOfAvengers: Int): List<SuperHero> =
         givenThereAreSomeSuperHeroes(numberOfAvengers, areAvengers = true)
 
@@ -84,15 +93,42 @@ class MainActivityTest : AcceptanceTest<MainActivity>(MainActivity::class.java) 
             )
         }
 
-        whenever(repository.getAllSuperHeroes()).thenReturn(singleValueLiveData(superHeroes))
+        whenever(repository.getAllSuperHeroes())
+            .thenReturn(singleValueLiveData(superHeroes.toPagedList()))
+
         return superHeroes
     }
 
     private fun givenThereAreNoSuperHeroes() {
-        whenever(repository.getAllSuperHeroes()).thenReturn(singleValueLiveData(emptyList()))
+        whenever(repository.getAllSuperHeroes())
+            .thenReturn(singleValueLiveData(emptyList<SuperHero>().toPagedList()))
     }
 
     override val testDependencies = Kodein.Module("Test dependencies", allowSilentOverride = true) {
         bind<SuperHeroRepository>() with instance(repository)
     }
+
+    private fun List<SuperHero>.toPagedList(): PagedList<SuperHero> =
+        PagedList.Builder(object : PositionalDataSource<SuperHero>() {
+            override fun loadRange(
+                params: LoadRangeParams,
+                callback: LoadRangeCallback<SuperHero>
+            ) {
+                callback.onResult(this@toPagedList)
+            }
+
+            override fun loadInitial(
+                params: LoadInitialParams,
+                callback: LoadInitialCallback<SuperHero>
+            ) {
+                callback.onResult(
+                    this@toPagedList,
+                    0,
+                    this@toPagedList.size
+                )
+            }
+        }, 100)
+            .setNotifyExecutor(newSingleThreadExecutor { Looper.getMainLooper().thread })
+            .setFetchExecutor(newSingleThreadExecutor { Looper.getMainLooper().thread })
+            .build()
 }

--- a/app/src/main/java/com/karumi/jetpack/superheroes/SuperHeroesApplication.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/SuperHeroesApplication.kt
@@ -6,6 +6,7 @@ import com.karumi.jetpack.superheroes.common.module
 import com.karumi.jetpack.superheroes.data.repository.LocalSuperHeroDataSource
 import com.karumi.jetpack.superheroes.data.repository.RemoteSuperHeroDataSource
 import com.karumi.jetpack.superheroes.data.repository.SuperHeroRepository
+import com.karumi.jetpack.superheroes.data.repository.SuperHeroesBoundaryCallback
 import com.karumi.jetpack.superheroes.data.repository.room.SuperHeroDao
 import org.kodein.di.DKodein
 import org.kodein.di.Kodein
@@ -41,9 +42,12 @@ class SuperHeroesApplication : Application(), KodeinAware {
             database.superHeroesDao()
         }
         bind<SuperHeroRepository>() with provider {
-            SuperHeroRepository(instance(), instance())
+            SuperHeroRepository(instance(), instance(), instance())
         }
-        bind<LocalSuperHeroDataSource>() with singleton {
+        bind<SuperHeroesBoundaryCallback>() with provider {
+            SuperHeroesBoundaryCallback(instance(), instance())
+        }
+        bind<LocalSuperHeroDataSource>() with provider {
             LocalSuperHeroDataSource(instance(), instance())
         }
         bind<RemoteSuperHeroDataSource>() with provider {

--- a/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/RemoteSuperHeroDataSource.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/RemoteSuperHeroDataSource.kt
@@ -15,11 +15,15 @@ class RemoteSuperHeroDataSource(
     private val superHeroes: MutableMap<String, SuperHero> =
         fakeData().associateBy { it.id }.toMutableMap()
 
-    fun getAllSuperHeroes(): LiveData<List<SuperHero>> {
+    fun getSuperHeroesPage(pageIndex: Int, pageSize: Int): LiveData<List<SuperHero>> {
         val allSuperHeroes = MutableLiveData<List<SuperHero>>()
         executor.execute {
             waitABit()
-            allSuperHeroes.postValue(superHeroes.values.toList().sortedBy { it.id })
+            val superHeroesPage = superHeroes.values.toList()
+                .sortedBy { it.id }
+                .drop(pageIndex * pageSize)
+                .take(pageSize)
+            allSuperHeroes.postValue(superHeroesPage)
         }
         return allSuperHeroes
     }

--- a/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/SuperHeroRepository.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/SuperHeroRepository.kt
@@ -2,22 +2,20 @@ package com.karumi.jetpack.superheroes.data.repository
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
+import androidx.paging.PagedList
 import com.karumi.jetpack.superheroes.domain.model.SuperHero
 
 class SuperHeroRepository(
     private val local: LocalSuperHeroDataSource,
-    private val remote: RemoteSuperHeroDataSource
+    private val remote: RemoteSuperHeroDataSource,
+    private val boundaryCallback: SuperHeroesBoundaryCallback
 ) {
-    fun getAllSuperHeroes(): LiveData<List<SuperHero>> = MediatorLiveData<List<SuperHero>>().apply {
-        val localSource = local.getAllSuperHeroes()
-        val remoteSource = remote.getAllSuperHeroes()
-
-        addSource(remoteSource) { superHeroes ->
-            removeSource(remoteSource)
-            addSource(localSource) { postValue(it) }
-            local.saveAll(superHeroes)
-        }
+    companion object {
+        const val PAGE_SIZE = 4
     }
+
+    fun getAllSuperHeroes(): LiveData<PagedList<SuperHero>> =
+        local.getAllSuperHeroes(PAGE_SIZE, boundaryCallback)
 
     fun get(id: String): LiveData<SuperHero?> = MediatorLiveData<SuperHero?>().apply {
         addSource(local.get(id)) {

--- a/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/SuperHeroesBoundaryCallback.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/SuperHeroesBoundaryCallback.kt
@@ -1,0 +1,35 @@
+package com.karumi.jetpack.superheroes.data.repository
+
+import androidx.lifecycle.Observer
+import androidx.paging.PagedList
+import com.karumi.jetpack.superheroes.domain.model.SuperHero
+
+class SuperHeroesBoundaryCallback(
+    private val local: LocalSuperHeroDataSource,
+    private val remote: RemoteSuperHeroDataSource
+) : PagedList.BoundaryCallback<SuperHero>() {
+
+    private var pageIndexAboutToLoad = 0
+
+    override fun onZeroItemsLoaded() {
+        pageIndexAboutToLoad = 0
+        loadNextPage()
+    }
+
+    override fun onItemAtEndLoaded(itemAtEnd: SuperHero) {
+        loadNextPage()
+    }
+
+    private fun loadNextPage() {
+        val remoteSuperHeroesPage =
+            remote.getSuperHeroesPage(pageIndexAboutToLoad, SuperHeroRepository.PAGE_SIZE)
+
+        remoteSuperHeroesPage.observeForever(object : Observer<List<SuperHero>> {
+            override fun onChanged(superHeroes: List<SuperHero>) {
+                local.saveAll(superHeroes)
+                remoteSuperHeroesPage.removeObserver(this)
+                pageIndexAboutToLoad++
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/room/SuperHeroDao.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/data/repository/room/SuperHeroDao.kt
@@ -1,6 +1,7 @@
 package com.karumi.jetpack.superheroes.data.repository.room
 
 import androidx.lifecycle.LiveData
+import androidx.paging.DataSource
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -10,7 +11,7 @@ import androidx.room.Update
 @Dao
 interface SuperHeroDao {
     @Query("SELECT * FROM superheroes ORDER BY superhero_id ASC")
-    fun getAll(): LiveData<List<SuperHeroEntity>>
+    fun getAll(): DataSource.Factory<Int, SuperHeroEntity>
 
     @Query("SELECT * FROM superheroes WHERE superhero_id = :id")
     fun getById(id: String): LiveData<SuperHeroEntity?>

--- a/app/src/main/java/com/karumi/jetpack/superheroes/domain/usecase/GetSuperHeroes.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/domain/usecase/GetSuperHeroes.kt
@@ -1,9 +1,11 @@
 package com.karumi.jetpack.superheroes.domain.usecase
 
 import androidx.lifecycle.LiveData
+import androidx.paging.PagedList
 import com.karumi.jetpack.superheroes.data.repository.SuperHeroRepository
 import com.karumi.jetpack.superheroes.domain.model.SuperHero
 
 class GetSuperHeroes(private val superHeroesRepository: SuperHeroRepository) {
-    operator fun invoke(): LiveData<List<SuperHero>> = superHeroesRepository.getAllSuperHeroes()
+    operator fun invoke(): LiveData<PagedList<SuperHero>> =
+        superHeroesRepository.getAllSuperHeroes()
 }

--- a/app/src/main/java/com/karumi/jetpack/superheroes/ui/view/BaseActivity.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/ui/view/BaseActivity.kt
@@ -28,7 +28,7 @@ abstract class BaseActivity<T : ViewDataBinding> : AppCompatActivity(), KodeinAw
     abstract val toolbarView: Toolbar
     abstract val activityModules: Kodein.Module
     abstract val viewModel: AndroidViewModel
-    protected lateinit var binding: T
+    private lateinit var binding: T
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/karumi/jetpack/superheroes/ui/view/MainActivity.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/ui/view/MainActivity.kt
@@ -3,6 +3,7 @@ package com.karumi.jetpack.superheroes.ui.view
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.Observer
+import androidx.paging.PagedList
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.karumi.jetpack.superheroes.R
 import com.karumi.jetpack.superheroes.common.bindViewModel
@@ -49,10 +50,8 @@ class MainActivity : BaseActivity<MainActivityBinding>() {
         recycler_view.adapter = adapter
     }
 
-    private fun showSuperHeroes(superHeroes: List<SuperHero>) {
-        adapter.clear()
-        adapter.addAll(superHeroes)
-        adapter.notifyDataSetChanged()
+    private fun showSuperHeroes(superHeroes: PagedList<SuperHero>) {
+        adapter.submitList(superHeroes)
     }
 
     private fun openDetail(id: String) {

--- a/app/src/main/java/com/karumi/jetpack/superheroes/ui/view/adapter/SuperHeroesAdapter.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/ui/view/adapter/SuperHeroesAdapter.kt
@@ -3,7 +3,8 @@ package com.karumi.jetpack.superheroes.ui.view.adapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
-import androidx.recyclerview.widget.RecyclerView
+import androidx.paging.PagedListAdapter
+import androidx.recyclerview.widget.DiffUtil
 import com.karumi.jetpack.superheroes.R
 import com.karumi.jetpack.superheroes.databinding.SuperHeroRowBinding
 import com.karumi.jetpack.superheroes.domain.model.SuperHero
@@ -11,13 +12,7 @@ import com.karumi.jetpack.superheroes.ui.viewmodel.SuperHeroesViewModel
 
 internal class SuperHeroesAdapter(
     private val viewModel: SuperHeroesViewModel
-) : RecyclerView.Adapter<SuperHeroViewHolder>() {
-    private val superHeroes: MutableList<SuperHero> = ArrayList()
-
-    fun addAll(collection: Collection<SuperHero>) {
-        superHeroes.addAll(collection)
-    }
-
+) : PagedListAdapter<SuperHero, SuperHeroViewHolder>(diffCallback) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SuperHeroViewHolder {
         val binding: SuperHeroRowBinding = DataBindingUtil.inflate(
             LayoutInflater.from(parent.context),
@@ -30,14 +25,17 @@ internal class SuperHeroesAdapter(
     }
 
     override fun onBindViewHolder(holder: SuperHeroViewHolder, position: Int) {
-        holder.render(superHeroes[position], viewModel)
+        val superHero = getItem(position) ?: return
+        holder.render(superHero, viewModel)
     }
 
-    override fun getItemCount(): Int {
-        return superHeroes.size
-    }
+    companion object {
+        private val diffCallback = object : DiffUtil.ItemCallback<SuperHero>() {
+            override fun areItemsTheSame(oldItem: SuperHero, newItem: SuperHero): Boolean =
+                oldItem.id == newItem.id
 
-    fun clear() {
-        superHeroes.clear()
+            override fun areContentsTheSame(oldItem: SuperHero, newItem: SuperHero): Boolean =
+                oldItem == newItem
+        }
     }
 }

--- a/app/src/main/java/com/karumi/jetpack/superheroes/ui/viewmodel/SuperHeroesViewModel.kt
+++ b/app/src/main/java/com/karumi/jetpack/superheroes/ui/viewmodel/SuperHeroesViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.paging.PagedList
 import com.karumi.jetpack.superheroes.domain.model.SuperHero
 import com.karumi.jetpack.superheroes.domain.usecase.GetSuperHeroes
 import com.karumi.jetpack.superheroes.ui.view.SingleLiveEvent
@@ -15,7 +16,7 @@ class SuperHeroesViewModel(
 
     val isLoading = MutableLiveData<Boolean>()
     val isShowingEmptyCase = MutableLiveData<Boolean>()
-    val superHeroes = MediatorLiveData<List<SuperHero>>()
+    val superHeroes = MediatorLiveData<PagedList<SuperHero>>()
     val idOfSuperHeroToOpen = SingleLiveEvent<String>()
 
     fun prepare() {


### PR DESCRIPTION
**This PR is not meant to be merged**

This is how to use the Paging component:

* Return `PagedList` instead of a simple `List` of elements (in this case, `SuperHero`). Room already gives support to it and deals with pagination for you but it's up to the developer to have a backing data source that supports pagination.
* Create a `BoundaryCallback` implementation. It is called whenever the `LivePagedListBuilder` created in the local data source runs out of elements. It has to fetch the new elements from somewhere, in our case from the `RemoteSuperHeroDataSource` and store them in the `LocalSuperHeroDataSource`. The API is too simple as it only returns the last item it found, that means that we have to deal with knowing what page is that in our system. In this PR we are just storing an index that is increasing with every new fetch but if the application would be more complex we'd have to create a fancier mechanism. BTW, the callback is a repository dependency because if I'd add it as a dependency of the local data source I'd be creating a dependency cycle.
* Replace the regular `RecyclerView.Adapter` by a `PagedListAdapter`. It is this element the one really firing the event in case we need more elements. It relies on you calling the `getItem` method so you are forced to call it from your implementation adapter even if it's not used.
* Because the paging adapter is using the diff'ing algorithm we are adding a short sleep in our tests to wait for animations to finish.